### PR TITLE
Perixx kbd fix

### DIFF
--- a/ps2.h
+++ b/ps2.h
@@ -63,6 +63,14 @@ class PS2Port
     /// @brief Process data on falling clock edge
     /// @attention This is interrupt code
     void onFallingClock() {
+      if (!inhibited && count()>=(size-1)){
+        inhibit();
+        return;
+      }
+      else if (inhibited){
+        return;
+      }
+
       if (ps2ddr == 0)
         receiveBit();
       else
@@ -78,14 +86,6 @@ class PS2Port
         resetReceiver();
       }
       lastBitMillis = curMillis;
-
-      if (!inhibited && count()>=(size-1)){
-        inhibit();
-        return;
-      }
-      else if (inhibited){
-        return;
-      }
 
       byte curBit = digitalRead(datPin);
       switch (rxBitCount)
@@ -338,7 +338,10 @@ class PS2Port
       inhibited=true;
       pinMode(clkPin, OUTPUT);
       digitalWrite(clkPin, LOW);
-      resetReceiver();
+      
+      curCode = 0;
+      parity = 0;
+      rxBitCount = 0;
     }
 
     void activate(){

--- a/ps2.h
+++ b/ps2.h
@@ -241,7 +241,6 @@ class PS2Port
       if (available()) {
         value = buffer[tail];
         tail = (tail + 1) & (size - 1);
-        return value;
       }
       if (inhibited && count() < (size-3)){
         activate();


### PR DESCRIPTION
A test to handle buffer full.

It inhibits the PS/2 communication when receiving a bit if the buffer is already full. It reactivates the PS/2 when at least three bytes have been removed from the buffer.

Please not that I have no hardware to test this code with.