### PR TITLE
Keyboard buffer full handling and more

### DIFF
--- a/mouse.cpp
+++ b/mouse.cpp
@@ -3,7 +3,7 @@
 #include "smc_pins.h"
 
 extern bool SYSTEM_POWERED;
-extern PS2Port<PS2_KBD_CLK, PS2_KBD_DAT, 16> Keyboard;
+extern PS2KeyboardPort<PS2_KBD_CLK, PS2_KBD_DAT, 16> Keyboard;
 extern PS2Port<PS2_MSE_CLK, PS2_MSE_DAT, 8> Mouse;
 
 MOUSE_INIT_STATE_T mouse_init_state = OFF;

--- a/mouse.cpp
+++ b/mouse.cpp
@@ -21,6 +21,7 @@ void MouseTick()
     mouse_init_state = OFF;
     watchdog_armed = false;
     watchdog_timer = 1023;
+    Mouse.reset();
     return;
   }
   if (watchdog_armed) {

--- a/mouse.h
+++ b/mouse.h
@@ -3,16 +3,16 @@
 
 enum mouse_command : uint8_t
 {
-  RESET = 0xFF,
-  ACK = 0xFA,
-  BAT_OK = 0xAA,
-  BAT_FAIL = 0xFC,
-  MOUSE_ID = 0x00,
-  SET_SAMPLE_RATE = 0xF3,
-  READ_DEVICE_TYPE = 0xF2,
+  RESET = 0xFF,                   // Reset device
+  ACK = 0xFA,                     // Acknowledge
+  BAT_OK = 0xAA,                  // Basic Acceptance Test passed
+  BAT_FAIL = 0xFC,                // Basic Acceptance Test failed
+  MOUSE_ID = 0x00,                // Mouse identifier
+  SET_SAMPLE_RATE = 0xF3,         // Mouse sample rate command
+  READ_DEVICE_TYPE = 0xF2,        // Request device type
   SET_RESOLUTION = 0xE8,
   SET_SCALING = 0xE6,
-  SET_STATUS_INDICATORS = 0xED,
+  SET_STATUS_INDICATORS = 0xED,   // Set status indicators (keyboard LEDs)
   ENABLE = 0xF4
 };
 

--- a/ps2.h
+++ b/ps2.h
@@ -344,7 +344,7 @@ template<uint8_t clkPin, uint8_t datPin, uint8_t size>
 class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
 {
   protected:
-    volatile bool bufferOverrun = false;      // Set to true on buffer full, and to false when buffer is empty again
+    volatile bool buffer_overrun = false;      // Set to true on buffer full, and to false when buffer is empty again
     volatile uint8_t scancode_state = 0x00;  // Tracks the type and byte position of the scan code currently receiving (bits 4-7 = scan code type, bits 0-3 = number of bytes)
     volatile uint8_t modifier_state = 0x00;  // Always tracks modifier key state, even if buffer is full
     volatile uint8_t modifier_oldstate = 0x00;   // Previous modifier key state, used to compare what's changed during buffer full
@@ -358,23 +358,23 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
        Processes a scan code byte received from the keyboard
     */
     void processByteReceived(uint8_t value) {
-      if (!bufferOverrun) {
+      if (!buffer_overrun) {
         if (!bufferAdd(value)) {
-          bufferOverrun = true;  // Buffer full
+          buffer_overrun = true;  // Buffer full
           bufferRemovePartialCode();
         }
       }
       else {
         if (!this->available() && scancode_state == 0x00) {
           if (putModifiers()) {
-            bufferOverrun = false;
+            buffer_overrun = false;
           }
         }
       }
       
       updateState(value);
 
-      if (!bufferOverrun) {
+      if (!buffer_overrun) {
       modifier_oldstate = modifier_state;
       }
     }
@@ -387,11 +387,13 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
     void updateState(uint8_t value) {      
       switch (scancode_state) {
         case 0x00:    // Start of new scan code
+          // Update state
           if (value == 0xf0) scancode_state = 0x11;   // Start of break code
-          else if (value == 0xab) scancode_state = 0x91;  // Start of two byte response to read ID command
+          else if (value == 0xab) scancode_state = 0x51;  // Start of two byte response to read ID command
           else if (value == 0xe0) scancode_state = 0x21;  // Start of extended code
-          else if (value == 0xe1) scancode_state = 0x81;  // Start of Pause key code
-          
+          else if (value == 0xe1) scancode_state = 0x41;  // Start of Pause key code
+
+          // Update modifier key status and check for Ctrl+Alt+PrtScr/Restore => NMI
           else if (value == 0x12) modifier_state |= PS2_MODIFIER_STATE::LSHIFT;
           else if (value == 0x59) modifier_state |= PS2_MODIFIER_STATE::RSHIFT;
           else if (value == 0x14) modifier_state |= PS2_MODIFIER_STATE::LCTRL;
@@ -401,8 +403,10 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           break;
 
         case 0x11:    // After 0xf0 (break code)
+          // Update state
           scancode_state = 0x00;
-          
+
+          // Update modifier key status
           if (value == 0x12) modifier_state &= ~PS2_MODIFIER_STATE::LSHIFT;
           else if (value == 0x59) modifier_state &= ~PS2_MODIFIER_STATE::RSHIFT;
           else if (value == 0x14) modifier_state &= ~PS2_MODIFIER_STATE::LCTRL;
@@ -411,10 +415,11 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           break;
 
         case 0x21:    // After 0xe0 (extended code)
-          if (value == 0xf0) scancode_state = 0x32; // Extended break code or Shift+Extended make code
-          else if (value == 0x12) scancode_state = 0x42;  // PrtScr make code or NumLock+extended make code
+          // Update state
+          if (value == 0xf0) scancode_state = 0x32; // Extended break code
           else scancode_state = 0x00;
 
+          // Update modifier key status and check for Ctrl+Alt+Del => Reset
           if (value == 0x14) modifier_state |= PS2_MODIFIER_STATE::RCTRL;
           else if (value == 0x1f) modifier_state |= PS2_MODIFIER_STATE::LWIN;
           else if (value == 0x27) modifier_state |= PS2_MODIFIER_STATE::RWIN;
@@ -423,12 +428,11 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           
           break;
 
-        case 0x32:    // After 0xe0 0xf0 (extended break code or Shift+Extended make code)
-          if (value == 0x7c) scancode_state = 0x53;   // PrtScr break code
-          else if (value == 0x12) scancode_state = 0x63;  // Shift+Extended make code
-          else if ((modifier_state & PS2_MODIFIER_STATE::LSHIFT) || (modifier_state & PS2_MODIFIER_STATE::RSHIFT)) scancode_state = 0x73; // Shift+Extended break code (5 bytes)
-          else scancode_state = 0x00;
+        case 0x32:    // After 0xe0 0xf0 (extended break code)
+          // Update state
+          scancode_state = 0x00;
 
+          // Update modifier key status
           if (value == 0x14) modifier_state &= ~PS2_MODIFIER_STATE::RCTRL;
           else if (value == 0x1f) modifier_state &= ~PS2_MODIFIER_STATE::LWIN;
           else if (value == 0x27) modifier_state &= ~PS2_MODIFIER_STATE::RWIN;
@@ -436,59 +440,24 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           
           break;
 
-        case 0x42:    // After 0xe0 0x12 (PrtScr make code or NumLock+extended make code)
-          scancode_state++;
-          break;
-
+        case 0x41:    // After 0xe1 (pause make code, 8 bytes)
+        case 0x42:
         case 0x43:
-          if (value == 0x71 && isCtrlAltDown()) reset_request = true;
-          scancode_state = 0x00;
-          break;        
-
-        case 0x53:    // After 0xe0 0xf0 0x7c (print screen break code)
-        case 0x54:
+        case 0x44:
+        case 0x45:
+        case 0x46:
           scancode_state++;
           break;
 
-        case 0x55:
+        case 0x47:
           scancode_state = 0x00;
           break;
 
-        case 0x63:    // After 0xe0 0xf0 0x12 (Shift+extended make code, 5 bytes)
+        case 0x51:    // After 0xab (two byte response to read ID command)
           scancode_state++;
           break;
           
-        case 0x64:
-          scancode_state = 0x00;
-          break;        
-
-        case 0x73:    // After 0xe0 0xf0 ??, where ?? != 7c and Shift is held down (NumLock+Extended break code, 6 bytes)
-        case 0x74:
-          scancode_state++;
-          break;
-          
-        case 0x75:
-          scancode_state = 0x00;
-          break;
-
-        case 0x81:    // After 0xe1 (pause make code)
-        case 0x82:
-        case 0x83:
-        case 0x84:
-        case 0x85:
-        case 0x86:
-          scancode_state++;
-          break;
-
-        case 0x87:
-          scancode_state = 0x00;
-          break;
-
-        case 0x91:    // After 0xab (two byte response to read ID command)
-          scancode_state++;
-          break;
-          
-        case 0x92:
+        case 0x52:
           scancode_state = 0x00;
           break;
       }
@@ -531,14 +500,14 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       
       scancode_state = 0;
       modifier_state = 0;
-      bufferOverrun = false;
+      buffer_overrun = false;
       nmi_request = false;
       reset_request = false;
     }
 
     void resetInput() {
       PS2Port<clkPin,datPin,size>::resetInput();
-      if (!bufferOverrun) {
+      if (!buffer_overrun) {
         bufferRemovePartialCode();
       }
       scancode_state = 0;

--- a/ps2.h
+++ b/ps2.h
@@ -395,6 +395,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           else if (value == 0x59) modifier_state |= PS2_MODIFIER_STATE::RSHIFT;
           else if (value == 0x14) modifier_state |= PS2_MODIFIER_STATE::LCTRL;
           else if (value == 0x11) modifier_state |= PS2_MODIFIER_STATE::LALT;
+          else if (value == 0x84 && isCtrlAltDown()) nmi_request = true;
           break;
 
         case 0x11:    // After 0xf0 (break code)
@@ -434,15 +435,13 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           break;
 
         case 0x43:
-          if (value == 0x7c) {
-            // Prt Scr
-            nmi_request = true;
-            scancode_state = 0x00;
-          }
-          else{
-            // Extended code after Num Lock decorator
-            scancode_state = 0x00;
-          }
+          if (value == 0x71 && isCtrlAltDown()) reset_request = true;
+          else if (value == 0x14) modifier_state |= PS2_MODIFIER_STATE::RCTRL;
+          else if (value == 0x1f) modifier_state |= PS2_MODIFIER_STATE::LWIN;
+          else if (value == 0x27) modifier_state |= PS2_MODIFIER_STATE::RWIN;
+          else if (value == 0x11) modifier_state |= PS2_MODIFIER_STATE::RALT;
+          
+          scancode_state = 0x00;
           break;        
 
         case 0x53:    // After 0xe0 0xf0 0x7c (print screen break code)

--- a/ps2.h
+++ b/ps2.h
@@ -434,6 +434,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
 
         case 0x43:
           scancode_state = 0x00;
+          nmi_request = true;
           break;
 
         case 0x53:    // After 0xe0 0xf0 0x7c (print screen break code)
@@ -456,7 +457,6 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
 
         case 0x67:
           scancode_state = 0x00;
-          nmi_request = true;
           break;
 
         case 0x71:    // After 0xab (two byte response to read ID command)

--- a/ps2.h
+++ b/ps2.h
@@ -495,7 +495,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
     bool putModifiers() {
       for (uint8_t i = 0; i < 8; i++) {
         if ((modifier_state & (1 << i)) != (modifier_snap & (1 << i))) {
-          if (i >= 3) {
+          if (i > 3) {
             if (!bufferAdd(0xe0)) return false;
             updateState(0xe0);
           }

--- a/ps2.h
+++ b/ps2.h
@@ -325,7 +325,6 @@ class PS2Port
 
     uint8_t count() {
       return (size + head - tail) & (size - 1);
-      processByteReceived(size);
     }
 
     virtual void processByteReceived(uint8_t value) {

--- a/ps2.h
+++ b/ps2.h
@@ -459,10 +459,6 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           break;
 
         case 0x51:    // After 0xab (two byte response to read ID command)
-          scancode_state++;
-          break;
-          
-        case 0x52:
           scancode_state = 0x00;
           break;
       }

--- a/ps2.h
+++ b/ps2.h
@@ -246,7 +246,7 @@ class PS2Port
 
     virtual void flush() {
       head = tail = 0;
-      lastBitMillis = 0;
+      //lastBitMillis = 0;
     }
 
     void reset() {
@@ -484,7 +484,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       modifier_state = 0;
       bufferClosed = false;
       this->head = this->tail = 0;
-      this->lastBitMillis = 0;
+      //this->lastBitMillis = 0;
     }
 
     /**

--- a/ps2.h
+++ b/ps2.h
@@ -382,7 +382,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       switch (scancode_state) {
         case 0x00:    // Scan code begin
           if (value == 0xf0) scancode_state = 0x11;   // Start of break code
-          else if (value == 0xf2) scancode_state = 0x71;  // Start of read ID return
+          else if (value == 0xab) scancode_state = 0x71;  // Start of two byte response to read ID command
           else if (value == 0xe0) scancode_state = 0x21;  // Start of extended code
           else if (value == 0xe1) scancode_state = 0x61;  // Start of Pause key code
           else if (value == 0x12) modifier_state |= PS2_MODIFIER_STATE::LSHIFT;
@@ -452,7 +452,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           scancode_state = 0x00;
           break;
 
-        case 0x71:    // After 0xf2 (two byte response to read ID command)
+        case 0x71:    // After 0xab (two byte response to read ID command)
           scancode_state++;
           break;
           

--- a/ps2.h
+++ b/ps2.h
@@ -382,6 +382,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       switch (scancode_state) {
         case 0x00:    // Scan code begin
           if (value == 0xf0) scancode_state = 0x11;   // Start of break code
+          else if (value == 0xf2) scancode_state = 0x71;  // Start of read ID return
           else if (value == 0xe0) scancode_state = 0x21;  // Start of extended code
           else if (value == 0xe1) scancode_state = 0x61;  // Start of Pause key code
           else if (value == 0x12) modifier_state |= PS2_MODIFIER_STATE::LSHIFT;
@@ -450,6 +451,11 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
         case 0x67:
           scancode_state = 0x00;
           break;
+
+        case 0x71:    // After 0xf2 (two byte response to read ID command)
+          scancode_state++;
+        case 0x72:
+          scancode_state = 0x00;
       }
     }
 

--- a/ps2.h
+++ b/ps2.h
@@ -46,7 +46,7 @@ class PS2Port
       flush();
     };
 
-    volatile resetInput(){
+    virtual resetInput(){
       curCode = 0;
       parity = 0;
       rxBitCount = 0;

--- a/ps2.h
+++ b/ps2.h
@@ -454,8 +454,12 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
 
         case 0x71:    // After 0xf2 (two byte response to read ID command)
           scancode_state++;
+          break;
+          
         case 0x72:
           scancode_state = 0x00;
+          break;
+          
       }
     }
 

--- a/ps2.h
+++ b/ps2.h
@@ -364,16 +364,16 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           // All modifier key state changes didn't fit in the buffer, remove possible partial scan code stored in the buffer
           bufferRemoveFromHead(scancode_state & 0x0f);
         }
-
-        if (!bufferClosed) {
-          if (!bufferAdd(value)) {
-            bufferClosed = true;
-            bufferRemoveFromHead(scancode_state & 0x0f);
-          }
-        }
-
-        updateState(value);
       }
+
+      if (!bufferClosed) {
+        if (!bufferAdd(value)) {
+          bufferClosed = true;
+          bufferRemoveFromHead(scancode_state & 0x0f);
+        }
+      }
+      
+      updateState(value);
     }
 
     /**
@@ -484,7 +484,8 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       scancode_state = 0;
       modifier_state = 0;
       bufferClosed = false;
-      PS2Port<clkPin, datPin, size>::flush();
+      this->head = this->tail = 0;
+      this->lastBitMillis = 0;
     }
 
     /**

--- a/ps2.h
+++ b/ps2.h
@@ -534,6 +534,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           if (!(modifier_state & (1 << i))) {
             if (!bufferAdd(0xf0)){
               bufferRemovePartialCode();
+              scancode_state = 0x00;
               return false;
             }
             if (scancode_state == 0x21) scancode_state = 0x32; else scancode_state = 0x11;
@@ -541,10 +542,11 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           
           if (!bufferAdd(modifier_codes[i])){
             bufferRemovePartialCode();
+            scancode_state = 0x00;
             return false;
           }
           
-          scancode_state = 0;
+          scancode_state = 0x00;
           modifier_oldstate = (modifier_oldstate & ~(1 << i)) | (modifier_state & (1 << i));
         }
       }

--- a/ps2.h
+++ b/ps2.h
@@ -228,7 +228,7 @@ class PS2Port
     };
 
     /// @brief Returns the next available byte from the PS/2 port
-    volatile uint8_t next() {
+    virtual uint8_t next() {
       if (available()) {
         uint8_t value = buffer[tail];
         tail = (tail + 1) & (size - 1);

--- a/ps2.h
+++ b/ps2.h
@@ -84,7 +84,9 @@ class PS2Port
       if (curMillis >= (lastBitMillis + SCANCODE_TIMEOUT_MS))
       {
         // Haven't heard from device in a while, assume this is a new keycode
-        resetReceiver();
+        curCode = 0;
+        parity = 0;
+        rxBitCount = 0;
       }
       lastBitMillis = curMillis;
 
@@ -341,10 +343,10 @@ template<uint8_t clkPin, uint8_t datPin, uint8_t size>
 class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
 {
   protected:
-    bool bufferClosed = false;      // Set to true on buffer full, and to false when buffer is empty again
-    uint8_t scancode_state = 0x00;  // Tracks the type and byte position of the scan code currently receiving (bits 4-7 = scan code type, bits 0-3 = number of bytes)
-    uint8_t modifier_state = 0x00;  // Always tracks modifier key state, even if buffer is full
-    uint8_t modifier_snap = 0x00;   // A copy of modifier_state is stored here on start of buffer full, used to compare what's changed when buffer is empty again
+    volatile bool bufferClosed = false;      // Set to true on buffer full, and to false when buffer is empty again
+    volatile uint8_t scancode_state = 0x00;  // Tracks the type and byte position of the scan code currently receiving (bits 4-7 = scan code type, bits 0-3 = number of bytes)
+    volatile uint8_t modifier_state = 0x00;  // Always tracks modifier key state, even if buffer is full
+    volatile uint8_t modifier_snap = 0x00;   // A copy of modifier_state is stored here on start of buffer full, used to compare what's changed when buffer is empty again
     uint8_t modifier_codes[8] = {0x11, 0x12, 0x14, 0x59, 0x11, 0x14, 0x1f, 0x27};  // Last byte of modifier key scan codes: LALT, LSHIFT, LCTRL, RSHIFT, RALT, RCTRL, LWIN, RWIN
 
   public:

--- a/ps2.h
+++ b/ps2.h
@@ -363,6 +363,13 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           bufferRemovePartialCode();
         }
       }
+      else {
+        if (!this->available() && scancode_state == 0x00) {
+          if (putModifiers()) {
+            bufferClosed = false;
+          }
+        }
+      }
       
       updateState(value);
 
@@ -496,21 +503,10 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       else {
         this->head = (this->head + size - (scancode_state & 0x0f)) & (size - 1);    // scancode_state bits 0-3 = number of bytes stored in buffer since last complete scancode
       }
-      scancode_state = 0;
     }
 
     uint8_t next(){
-      uint8_t value = PS2Port<clkPin,datPin,size>::next();
-
-      if (bufferClosed && this->count() == 0) {
-        // Buffer has been full, but is now empty - Before opening up the buffer, put modifier key state changes in the buffer
-        if (putModifiers()) {
-          // Successfully put all modifier key state changes that occurred during buffer closed; open buffer
-          bufferClosed = false;
-        }
-      }
-      
-      return value;
+      return PS2Port<clkPin,datPin,size>::next();
     }
 
     void flush(){
@@ -528,6 +524,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
       if (!bufferClosed) {
         bufferRemovePartialCode();
       }
+      scancode_state = 0;
     }
 
 

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -59,7 +59,6 @@ bool I2C_Active = false;
 char echo_byte = 0;
 
 void setup() {  
-  Serial.begin(9600);
 #if defined(USE_SERIAL_DEBUG)
     Serial.begin(SERIAL_BPS);
 #endif

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -157,6 +157,11 @@ void loop() {
         //error handling?
     }
 
+    if (Keyboard.getResetRequest()) {
+     Reset_Button_Hold();
+     Keyboard.ackResetRequest();
+    }
+
 #if defined(KBDBUF_FULL_DBG)
     if (Keyboard.getByteCount()>19){
       uint8_t c = Keyboard.next();

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -4,7 +4,7 @@
 //     Michael Steil
 //     Joe Burks
 
-#define ENABLE_NMI_BUT
+//#define ENABLE_NMI_BUT
 //#define KBDBUF_FULL_DBG
 
 #include "smc_button.h"
@@ -129,12 +129,12 @@ void setup() {
     analogWrite(ACT_LED, 0);
 
     pinMode(RESB_PIN,OUTPUT);
-    digitalWrite(RESB_PIN,LOW);                 // Hold Reset on statup
+    digitalWrite(RESB_PIN,LOW);                 // Hold Reset on startup
 
-#if defined(ENABLE_NMI_BUT)
+//#if defined(ENABLE_NMI_BUT)
     pinMode(NMIB_PIN,OUTPUT);
     digitalWrite(NMIB_PIN,HIGH);
-#endif
+//#endif
 
     // PS/2 host init
     Keyboard.begin(keyboardClockIrq);

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -131,10 +131,8 @@ void setup() {
     pinMode(RESB_PIN,OUTPUT);
     digitalWrite(RESB_PIN,LOW);                 // Hold Reset on startup
 
-//#if defined(ENABLE_NMI_BUT)
     pinMode(NMIB_PIN,OUTPUT);
     digitalWrite(NMIB_PIN,HIGH);
-//#endif
 
     // PS/2 host init
     Keyboard.begin(keyboardClockIrq);

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -144,7 +144,7 @@ void loop() {
     NMI_BUT.tick();
 #endif
     MouseTick();
-    //KeyboardTick();
+    KeyboardTick();
     
     if ((SYSTEM_POWERED == 1) && (!digitalRead(PWR_OK)))
     {

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -136,11 +136,8 @@ void setup() {
     // PS/2 host init
     Keyboard.begin(keyboardClockIrq);
     Mouse.begin(mouseClockIrq);
-
-    Keyboard.processByteReceived(0x14);
 }
 
-volatile uint16_t counter=0;
 void loop() {
     POW_BUT.tick();                             // Check Button Status
     RES_BUT.tick();
@@ -156,14 +153,6 @@ void loop() {
         //kill power if PWR_OK dies, and system on
         //error handling?
     }
-
-    uint8_t c = Keyboard.next();
-    if (c!=0 && counter==0){
-      Serial.print(c, HEX);
-      Serial.print(" ");
-    }
-    if (c==0x1c) counter = 100;
-    if (counter>0) counter--;
 
     // DEBUG: turn activity LED on if there are keys in the keybuffer
     delay(10);                                  // Short Delay, required by OneButton if code is short   

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -5,6 +5,7 @@
 //     Joe Burks
 
 //#define ENABLE_NMI_BUT
+//#define KBDBUF_FULL_DBG
 
 #include "smc_button.h"
 #include <Wire.h>
@@ -60,6 +61,9 @@ char echo_byte = 0;
 
 void setup() {  
 #if defined(USE_SERIAL_DEBUG)
+    Serial.begin(SERIAL_BPS);
+#endif
+#if defined(KBDBUF_FULL_DBG)
     Serial.begin(SERIAL_BPS);
 #endif
 
@@ -152,6 +156,16 @@ void loop() {
         //kill power if PWR_OK dies, and system on
         //error handling?
     }
+
+#if defined(KBDBUF_FULL_DBG)
+    if (Keyboard.getByteCount()>19){
+      uint8_t c = Keyboard.next();
+      if (c!=0){
+        Serial.print(c, HEX);
+        Serial.print(" ");
+      }
+    }
+#endif
 
     // DEBUG: turn activity LED on if there are keys in the keybuffer
     delay(10);                                  // Short Delay, required by OneButton if code is short   

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -162,6 +162,11 @@ void loop() {
      Keyboard.ackResetRequest();
     }
 
+    if (Keyboard.getNMIRequest()) {
+      Reset_Button_Press();
+      Keyboard.ackNMIRequest();
+    }
+
 #if defined(KBDBUF_FULL_DBG)
     if (Keyboard.getByteCount()>19){
       uint8_t c = Keyboard.next();
@@ -193,7 +198,7 @@ void I2C_Receive(int) {
 
     int ct=0;
     while (Wire.available()) {
-        if (ct<3) {                             // read first two bytes only
+        if (ct<3) {                             // read first three bytes only
             byte c = Wire.read();
             I2C_Data[ct] = c;
             ct++;
@@ -202,7 +207,9 @@ void I2C_Receive(int) {
             Wire.read();                        // eat extra data, should not be sent
         }
     }
-    if (ct == 2 || ct == 3) {
+
+    if ((ct == 2 && I2C_Data[0] != 0x1a) || (ct == 3 && I2C_Data[0] == 0x1a)) {
+        // Offset 0x1a (Send two-byte command) requires three bytes, the other offsets require two bytes
         I2C_Process();                          // process received cmd
     }
 }

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -4,7 +4,7 @@
 //     Michael Steil
 //     Joe Burks
 
-//#define ENABLE_NMI_BUT
+#define ENABLE_NMI_BUT
 //#define KBDBUF_FULL_DBG
 
 #include "smc_button.h"


### PR DESCRIPTION
This pull request adds a new Keyboard PS/2 port child class. The main purpose of this was to implement buffer full handling.

The buffer full handling basically does the following:

- It tracks how many bytes have been saved to the buffer since the start of the current scan code
- If the scan code doesn't fit in the buffer it is completely removed from the buffer, and the buffer is closed for new scan codes
- While the buffer is closed for new scan codes, it still tracks the state of modifier keys. 
- When the buffer is empty again, changes to the state of modifier keys that happened while the buffer was closed are first outputted to the buffer, and thereafter the buffer is open for new scan codes

If Ctrl+Alt+Delete are held down, a reset request flag is set within the child class. The main loop reads this flag and if set resets the computer in the same way as when the reset button is held down.

The base PS/2 port class did call resetReceiver() when receiving the first bit of a scan code if more than 50 ms had passed since receiving the last bit of the previous scan code. This cleared the buffer, and in practical terms prevented the buffer to hold more than one scan code at a time. This has been changed. The keyboard now only removes a partial scan code from the head of the buffer in case of timeout.

The code has only been tested with a keyboard as I currently have no functional PS/2 mouse.